### PR TITLE
Bumping guava version to address CVE-2018-10237

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Run these commands from the same folder as this readme. Tweak the Dockerfile to meet your needs.
 
 ```bash
-docker build --rm -f "Dockerfile" -t jankins .
+docker build --pull --rm -f "Dockerfile" -t jankins .
 ```
 
 # Run

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <groovy.version>2.4.8</groovy.version>
         <groovy.spock.version>1.1-groovy-2.4</groovy.spock.version>
         <groovy.gmaven.pluginVersion>1.6.1</groovy.gmaven.pluginVersion>
-        <google.guava.version>20.0</google.guava.version>
+        <google.guava.version>[24.1.1,)</google.guava.version>
 
         <jenkins-spock.version>2.1.2</jenkins-spock.version>
         <jenkins.version>2.102</jenkins.version>


### PR DESCRIPTION
Bumping guava version to address [CVE-2018-10237](https://github.com/advisories/GHSA-mvr2-9pj6-7w5j)

cc @jvanceACX 