### PR TITLE
Updated node.js to pull latest lts (erbium)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,13 @@ FROM jenkins/jenkins:lts
 USER root
 
 # Install Node.js
-RUN apt-get update && apt-get install -y wget tar
-RUN wget https://nodejs.org/dist/v12.17.0/node-v12.17.0-linux-x64.tar.gz
-RUN tar --strip-components 1 -xzvf node-v* -C /usr/local && rm node-*-linux-x64.tar.gz
+# Accepting a build arg to target a specific version
+# else we're going to take the lts (erbium at the time of authoring this file)
+ARG NODE_VERSION=
+RUN apt-get update && apt-get install -y wget tar sed
+RUN export NODE_VERSION=${NODE_VERSION:-$(wget -qO- https://nodejs.org/dist/latest-erbium/ | sed -nE 's|.*>node-(.*)\.pkg</a>.*|\1|p')} \
+        wget https://nodejs.org/dist/${NODE_VERSION}/${NODE_VERSION}-linux-x64.tar.gz \
+    &&  tar --strip-components 1 -xzvf node-v* -C /usr/local && rm node-*-linux-x64.tar.gz
 
 # Install groovy
 RUN apt-get install -y groovy

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG NODE_VERSION=
 RUN apt-get update && apt-get install -y wget tar sed
 RUN export NODE_VERSION=${NODE_VERSION:-$(wget -qO- https://nodejs.org/dist/latest-erbium/ | sed -nE 's|.*>node-(.*)\.pkg</a>.*|\1|p')} \
     &&  wget https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz \
-    &&  tar --strip-components 1 -xzvf node-v* -C /usr/local && rm node-*-linux-x64.tar.gz
+    &&  tar --strip-components 1 -xzf node-v* -C /usr/local && rm node-*-linux-x64.tar.gz
 
 # Install groovy
 RUN apt-get install -y groovy

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ USER root
 ARG NODE_VERSION=
 RUN apt-get update && apt-get install -y wget tar sed
 RUN export NODE_VERSION=${NODE_VERSION:-$(wget -qO- https://nodejs.org/dist/latest-erbium/ | sed -nE 's|.*>node-(.*)\.pkg</a>.*|\1|p')} \
-        wget https://nodejs.org/dist/${NODE_VERSION}/${NODE_VERSION}-linux-x64.tar.gz \
+    &&  wget https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz \
     &&  tar --strip-components 1 -xzvf node-v* -C /usr/local && rm node-*-linux-x64.tar.gz
 
 # Install groovy


### PR DESCRIPTION
Updated node.js to pull latest lts (erbium) unless prompted with specific version during build