### PR TITLE
Bugfix/fix build

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 *An [image base](https://www.docker.com/) for linting and ci/cd of [Jenkinsfiles](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/) and related [Shared Libraries](https://www.jenkins.io/doc/book/pipeline/shared-libraries/) written in [groovy](https://en.wikipedia.org/wiki/Apache_Groovy).*
 
-# Build
+## Build
 
 Run these commands from the same folder as this readme. Tweak the Dockerfile to meet your needs.
 
@@ -14,7 +14,7 @@ Run these commands from the same folder as this readme. Tweak the Dockerfile to 
 docker build --pull --rm -f "Dockerfile" -t jankins .
 ```
 
-# Run
+## Run
 
 ```bash
 # Start the container and run bash interactively
@@ -25,7 +25,8 @@ docker run --rm -p '8081:8080' -it -e JENKINS_EXECUTORS=4 -e JENKINS_USER='admin
 # Exposed as: http://0.0.0.0:8081
 ```
 
-## Run Params
+### Run Params
+
 - The Jenkins env can be customized at runtime via the following [Docker env vars](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file). Sample values are shown below.
 
 ```ini
@@ -34,7 +35,8 @@ JENKINS_PASSWD=jankins
 JENKINS_EXECUTORS=1
 ```
 
-# Related Links & Credits
+## Related Links & Credits
+
 - [jankins](https://github.com/calebHankins/jankins) logo derived from the [Jenkins project](https://jenkins.io/) artwork, supplied by [@jvanceACX](https://github.com/jvanceACX).
 - [Jake Wernette's awesome series on Jenkins Shared Libraries](https://itnext.io/jenkins-shared-libraries-part-1-5ba3d072536a).
 - [Jenkins Official Docker hub](https://hub.docker.com/r/jenkins/jenkins).

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,11 @@
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
+        <repository>
+            <id>jenkins-releases</id>
+            <name>Jenkins Releases</name>
+            <url>http://repo.jenkins-ci.org/releases</url>
+        </repository>
     </repositories>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -10,9 +10,8 @@
 
     <repositories>
         <repository>
-            <id>jenkins-releases</id>
-            <name>Jenkins Releases</name>
-            <url>http://repo.jenkins-ci.org/releases</url>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <google.guava.version>[24.1.1,)</google.guava.version>
 
         <jenkins-spock.version>2.1.2</jenkins-spock.version>
-        <jenkins.version>2.102</jenkins.version>
+        <jenkins.version>2.283</jenkins.version>
         <jenkins.servlet.version>3.1.0</jenkins.servlet.version>
         <jenkins.workflow.cps.version>2.36</jenkins.workflow.cps.version>
         <jenkins.workflow.basic.steps.version>2.6</jenkins.workflow.basic.steps.version>


### PR DESCRIPTION
updated jenkins-ci.org repo after build failures started Wednesday, June 9, 2021 at 01:33:18CDT
bumped jenkins version to 2.283