### PR TITLE
Updating node.js install to be static instead of supplied by build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,12 @@ FROM jenkins/jenkins:lts
 
 USER root
 
-# Install Node.js
-# Accepting a build arg to target a specific version
-# else we're going to take the lts (erbium at the time of authoring this file)
-ARG NODE_VERSION=
-RUN apt-get update && apt-get install -y wget tar sed
-RUN export NODE_VERSION=${NODE_VERSION:-$(wget -qO- https://nodejs.org/dist/latest-gallium/ | sed -nE 's|.*>node-(.*)\.pkg</a>.*|\1|p')} \
-    &&  wget https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz \
-    &&  tar --strip-components 1 -xzf node-v* -C /usr/local && rm node-*-linux-x64.tar.gz
+# Install Node.js & npm
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN apt install -y nodejs
+RUN npm install -g npm
+RUN echo NODE_ENV:$NODE_ENV
+RUN node --version && npm --version
 
 # Install groovy
 RUN apt-get install -y groovy


### PR DESCRIPTION
* Updating node.js install to be static instead of supplied by build arg. Currently pinned to active lts (v16)
* Updating npm to latest at build time