### PR TITLE
Bugfix/research memory issues downstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM jenkins/jenkins:lts
+FROM jenkins/jenkins:2.414.2-lts-jdk11
 
 USER root
+
+# Since we're pinning to bullseye for now due to dome downstream issues, do upgrade as soon as we start
+RUN apt update || true; apt upgrade || true;
 
 # Install Node.js & npm
 # @see: https://github.com/nodesource/distributions#debian-versions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.414.2-lts-jdk11
+FROM jenkins/jenkins:lts-slim-jdk11
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:lts-slim-jdk11
+FROM jenkins/jenkins:2.414
 
 USER root
 


### PR DESCRIPTION
The downstream issues seem to be related to the main jenkins/jenkins:lts upgrading from Bullseye to Bookworm. For now going to pin Jankins to the last Bullseye release. Longer term if this project isn't archived I'm thinking we pivot over to RHEL UBI based builds. 

cc @jvanceACX 

For more details:
- <https://www.jenkins.io/changelog-stable/>
  - <https://github.com/jenkinsci/docker/pull/1687>
    - <https://github.com/jenkinsci/docker/issues/1686>
      - [apt fails on fips-enabled hosts #1694](https://github.com/jenkinsci/docker/issues/1694)