### PR TITLE
Refactor npm-groovy-lint commands to remove architecture check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,10 +77,9 @@ RUN --mount=type=cache,target=/root/.m2 mvn clean test
 # @info The linter will print 1 or more lines of non-json text, adding a grep to only save lines starting with a '{'
 COPY ./scripts ./scripts
 COPY ./.groovylintrc.json ./.groovylintrc.json
-# npm-groovy-lint doesn't support arm64
-RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then mkdir -p ./logs && npm-groovy-lint --output 'json' | grep '^{' > './logs/groovyLintResults.json'; fi
-RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then cat './logs/groovyLintResults.json'; fi
-RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then node ./scripts/checkGroovyLintResults.js; fi
+RUN mkdir -p ./logs && npm-groovy-lint --output 'json' | grep '^{' > './logs/groovyLintResults.json'
+RUN cat './logs/groovyLintResults.json'
+RUN node ./scripts/checkGroovyLintResults.js
 
 # todo, roll a custom bootstrap around the entrypoint, only spin up jenkins app if we have pipelines to validate
 # ENTRYPOINT [ "bash" ]


### PR DESCRIPTION
At one time Apple silicon wasn't supported, but it seems like the arm64 support has been added. 